### PR TITLE
Upgrading clojure and kixi.comms

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,12 +10,12 @@
                  [bidi "2.0.12"]
                  [clj-http "3.5.0"]
                  [com.amazonaws/aws-java-sdk "1.11.53" :exclusions [joda-time]]
-                 [com.taoensso/timbre "4.8.0"]                 
+                 [com.taoensso/timbre "4.8.0"]
                  [de.ubercode.clostache/clostache "1.4.0"]
-                 [kixi/kixi.comms "0.2.13"]
+                 [kixi/kixi.comms "0.2.27"]
                  [kixi/kixi.log "0.1.4"]
                  [kixi/kixi.metrics "0.4.0"]
-                 [org.clojure/clojure "1.9.0-alpha14"]
+                 [org.clojure/clojure "1.9.0-alpha17"]
                  [yada/lean "1.2.2"]]
   :repl-options {:init-ns user}
   :global-vars {*warn-on-reflection* true

--- a/src/kixi/mailer/ses.clj
+++ b/src/kixi/mailer/ses.clj
@@ -10,7 +10,6 @@
 
 (defn invalid-rejected
   [cmd explaination]
-(prn cmd)
   {:kixi.comms.event/key :kixi.mailer/mail-rejected
    :kixi.comms.event/version "1.0.0"
    :kixi.comms.event/payload {:reason :mail-invalid

--- a/src/kixi/mailer/system.clj
+++ b/src/kixi/mailer/system.clj
@@ -3,9 +3,7 @@
             [clojure.java.io :as io]
             [com.stuartsierra.component
              :as
-             component
-             :refer
-             [system-map system-using]]
+             component]
             [kixi
              [comms :as comms]
              [log :as kixi-log]]
@@ -27,7 +25,7 @@
 
 (defn new-system-map
   [config]
-  (system-map
+  (component/system-map
    :communications (case (first (keys (:communications config)))
                      :kinesis (kinesis/map->Kinesis {}))
    :mailer (m/map->Mailer {})
@@ -72,5 +70,4 @@
     (configure-logging config)
     (-> (new-system-map config)
         (configure-components config profile)
-        (system-using component-dependencies))))
-
+        (component/system-using component-dependencies))))

--- a/test/kixi/integration/ses_test.clj
+++ b/test/kixi/integration/ses_test.clj
@@ -50,7 +50,7 @@
     (delete-tables dynamodb-endpoint [(kinesis/event-worker-app-name app profile)
                                       (kinesis/command-worker-app-name app profile)]))
   (when teardown-kinesis
-    (kinesis/delete-streams! endpoint (vals streams))))
+    (kinesis/delete-streams! {:endpoint endpoint} (vals streams))))
 
 (defn cycle-system-fixture
   [all-tests]

--- a/test/kixi/integration/ses_test.clj
+++ b/test/kixi/integration/ses_test.clj
@@ -3,7 +3,7 @@
             [clj-http.client :as client]
             [clojure
              [test :refer :all]]
-            [clojure.spec.test :as stest]
+            [clojure.spec.test.alpha :as stest]
             [clojure.core.async :as async]
             [environ.core :refer [env]]
             [kixi.comms.components.kinesis :as kinesis]
@@ -139,7 +139,8 @@
     "1.0.0"
     {:kixi.user/id uid
      :kixi.user/groups (vec-if-not ugroup)}
-    mail)))
+    mail
+    {:kixi.comms.command/partition-key uid})))
 
 (defn send-mail
   ([uid mail]

--- a/test/kixi/mailer_test.clj
+++ b/test/kixi/mailer_test.clj
@@ -2,8 +2,8 @@
   (:require [amazonica.aws.simpleemail :as email]
             [clojure.java.io :as io]
             [clojure.test :refer :all]
-            [clojure.spec :as s]
-            [clojure.spec.test :as st]
+            [clojure.spec.alpha :as s]
+            [clojure.spec.test.alpha :as st]
             [kixi.mailer.ses :as m]))
 
 (def example-payload {:destination {:to-addresses ["example@example.com"]}


### PR DESCRIPTION
Upgrading both clojure version and kixi.comms, one requires the other
so have to come together.

The comms change means all events must provide an explicit partition
key, code changes made to provide those.