### PR TITLE
Add 'dry run' support

### DIFF
--- a/resources/config.edn
+++ b/resources/config.edn
@@ -1,16 +1,16 @@
 {:service-name "kixi.mailer"
  :mailer {:ses #profile {:local {:endpoint "eu-west-1"
                                  :base-url "https://www.staging.witanforcities.com"
-                                 :dry-run? #or #[#env DRY_RUN false]}
+                                 :dry-run? #or [#env DRY_RUN false]}
                          :staging-jenkins {:endpoint "eu-west-1"
                                            :base-url "https://www.staging.witanforcities.com"
-                                           :dry-run? #or #[#env DRY_RUN false]}
+                                           :dry-run? #or [#env DRY_RUN false]}
                          :staging {:endpoint "eu-west-1"
                                    :base-url "https://staging.witanforcities.com"
-                                   :dry-run? #or #[#env DRY_RUN false]}
+                                   :dry-run? #or [#env DRY_RUN false]}
                          :prod {:endpoint "eu-west-1"
                                 :base-url "https://witanforcities.com"
-                                :dry-run? #or #[#env DRY_RUN false]}}}
+                                :dry-run? #or [#env DRY_RUN false]}}}
  :logging {:level #profile {:default :info
                             :prod :error} ; e/o #{:trace :debug :info :warn :error :fatal :report}
            ;; Control log filtering by namespaces/patterns. Useful for turning off

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -1,12 +1,16 @@
 {:service-name "kixi.mailer"
  :mailer {:ses #profile {:local {:endpoint "eu-west-1"
-                                 :base-url "https://www.staging.witanforcities.com"}
+                                 :base-url "https://www.staging.witanforcities.com"
+                                 :dry-run? #or #[#env DRY_RUN false]}
                          :staging-jenkins {:endpoint "eu-west-1"
-                                           :base-url "https://www.staging.witanforcities.com"}
+                                           :base-url "https://www.staging.witanforcities.com"
+                                           :dry-run? #or #[#env DRY_RUN false]}
                          :staging {:endpoint "eu-west-1"
-                                   :base-url "https://staging.witanforcities.com"}
+                                   :base-url "https://staging.witanforcities.com"
+                                   :dry-run? #or #[#env DRY_RUN false]}
                          :prod {:endpoint "eu-west-1"
-                                :base-url "https://witanforcities.com"}}}
+                                :base-url "https://witanforcities.com"
+                                :dry-run? #or #[#env DRY_RUN false]}}}
  :logging {:level #profile {:default :info
                             :prod :error} ; e/o #{:trace :debug :info :warn :error :fatal :report}
            ;; Control log filtering by namespaces/patterns. Useful for turning off

--- a/src/kixi/mailer/ses.clj
+++ b/src/kixi/mailer/ses.clj
@@ -253,6 +253,8 @@
   component/Lifecycle
   (start [component]
     (log/info "Starting SES mailer" directory)
+    (when dry-run?
+      (log/warn "The mailer is in DRY RUN mode. No emails will actually be sent."))
     (merge component
            (when-not send-mail-handler
              {:send-mail-handler


### PR DESCRIPTION
A 'dry run' would generate the appropriate commands and events, but would not actually send the emails. This also mitigates heimdall group resolution. A warning message is displayed when in this mode.