### PR TITLE
Add `:directory` to component overrides

### DIFF
--- a/test/kixi/integration/ses_test.clj
+++ b/test/kixi/integration/ses_test.clj
@@ -52,7 +52,7 @@
 (defn cycle-system-fixture
   [all-tests]
   (if run-against-staging
-    (user/start {} [:communications])
+    (user/start {} [:communications :directory])
     (user/start {:communications (coreasync/map->CoreAsync
                                   {:profile profile})} nil))
   (try (stest/instrument)


### PR DESCRIPTION
This should allow the directory kv to appear in the user system